### PR TITLE
LSTM - remove redundant bias term

### DIFF
--- a/model/LSTM.lua
+++ b/model/LSTM.lua
@@ -28,7 +28,7 @@ function LSTM.lstm(input_size, rnn_size, n, dropout)
     end
     -- evaluate the input sums at once for efficiency
     local i2h = nn.Linear(input_size_L, 4 * rnn_size)(x):annotate{name='i2h_'..L}
-    local h2h = nn.Linear(rnn_size, 4 * rnn_size)(prev_h):annotate{name='h2h_'..L}
+    local h2h = nn.Linear(rnn_size, 4 * rnn_size, false)(prev_h):annotate{name='h2h_'..L} -- no need for bias here
     local all_input_sums = nn.CAddTable()({i2h, h2h})
 
     local reshaped = nn.Reshape(4, rnn_size)(all_input_sums)


### PR DESCRIPTION
Since i2h and h2h terms are later added, no need to have bias in each of the linear transforms that yield i2h and h2h.

This is not an error, but resulting LSTM has few extra (wasted) parameters.
